### PR TITLE
tgi-gaudi fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MLPERF4.0/Inference/llama/tgi-gaudi"]
+	path = MLPERF4.0/Inference/llama/tgi-gaudi
+	url = https://github.com/huggingface/tgi-gaudi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "MLPERF4.0/Inference/llama/tgi-gaudi"]
-	path = MLPERF4.0/Inference/llama/tgi-gaudi
-	url = https://github.com/huggingface/tgi-gaudi.git


### PR DESCRIPTION
tgi-gaudi is not added correctly from the internal repo to Model-References.

This patch fixes it.