### PR TITLE
[PyTorch/computer_vision] pass dtype to HPUModel in HPUJITModel init

### DIFF
--- a/PyTorch/computer_vision/classification/torchvision/inference.py
+++ b/PyTorch/computer_vision/classification/torchvision/inference.py
@@ -181,7 +181,7 @@ class HPUJITModel(HPUModel):
             model = torch.jit.load(traced_model_path, map_location=torch.device('cpu'))
             model.to(device=HPU)
         else:
-            super().__init__(model_def, parameters_path, model_path=model_path)
+            super().__init__(model_def, parameters_path, model_path=model_path, dtype=dtype)
             self._trace(example_input)
 
     def _trace(self, example_input):


### PR DESCRIPTION
# Description

Fix computer vision model ResNet50, ResNeXt101 inference on IILSVRC2012-val dataset
Using torch.jit.trace model, Eager mode with torch.compile enabled, FP32 precision

Dependencies:
[ `Model-References/PyTorch/computer_vision/classification/torchvision/inference.py`](https://github.com/HabanaAI/Model-References/blob/0cff853e983dac7fa04d2aeb5ee4ba5e75f340b8/PyTorch/computer_vision/classification/torchvision/inference.py#L85)


## Type of changes

Please specify the type of changes, and delete the options that are not relevant.

- [ ] Documentation update
- [x] Bug fix (changes which fix an issue)
- [ ] Others (please specify)

## Tests

Tried `Model-References/PyTorch/computer_vision/classification/` -> [Inference and Examples
](https://github.com/HabanaAI/Model-References/tree/master/PyTorch/computer_vision/classification/torchvision#inference-and-examples)
* ResNet50, with torch.jit.trace model, Eager mode with torch.compile enabled, FP32 precision, batch size 256, habana_dataloader (with hardware decode support on Gaudi 2), 1 HPU on a single server under

Without code change in this commit, [Line 179](https://github.com/HabanaAI/Model-References/blob/0cff853e983dac7fa04d2aeb5ee4ba5e75f340b8/PyTorch/computer_vision/classification/torchvision/inference.py#L179) and [Line 85](https://github.com/HabanaAI/Model-References/blob/0cff853e983dac7fa04d2aeb5ee4ba5e75f340b8/PyTorch/computer_vision/classification/torchvision/inference.py#L85) would print "Inference data type float32" and "Inference data type bfloat16", respectively. The actual inference will also be using mixed precision BF16 instead of FP32.
<img src="https://github.com/HabanaAI/Model-References/assets/170357112/1f77f68c-2777-4157-b87c-87befc6c3c87" width="250" />

With code change, the inference would indeed use FP32.
<img src="https://github.com/HabanaAI/Model-References/assets/170357112/de7e4894-2286-45d9-ae59-c5578f92198b" width="250" />

## Checklist

- [x] I agree with the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] My code conforms to the following coding guidelines:
  - [x] Use Python 3
  - [x] Python code follows [PEP 8 Coding Styles](https://www.python.org/dev/peps/pep-0008/)
- [x] I have performed a self code review.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
