### PR TITLE
Fix the NLTKSegmenter failure issue

### DIFF
--- a/PyTorch/nlp/DeepSpeedExamples/deepspeed-bert/data/TextSharding.py
+++ b/PyTorch/nlp/DeepSpeedExamples/deepspeed-bert/data/TextSharding.py
@@ -316,7 +316,7 @@ class Sharding:
 
 import nltk
 
-nltk.download('punkt')
+nltk.download('punkt_tab')
 
 class NLTKSegmenter:
     def __init(self):


### PR DESCRIPTION
To fix the NLTKSegmenter failure issue.

With this change, the wiki files can be shared successfully.

Otherwise, error will report as follows:
ValueError: /root/Model-Reference/PyTorch/nlp/DeepSpeedExamples/deepspeed-bert/data/shared_training_shards_256_test_shards_256_fraction_0.1/wikicorpus_en/wikicorpos_en_test_xxx.txt is not a valid path

# Description

> :memo: Please include a summary of the changes. 
>   nltk.download('punkt')  ->  nltk.download('punkt_tab')
> * List any dependencies that are required for the changes.  

## Type of changes

Please specify the type of changes, and delete the options that are not relevant.

- [ ] Documentation update
- [X] Bug fix (changes which fix an issue)
- [ ] Others (please specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  Before the change:
![image](https://github.com/user-attachments/assets/f7dc9e67-2d68-41e1-9fe9-b662dd546ccd)
After the change:
![image](https://github.com/user-attachments/assets/3252f798-ed22-4f4d-96d2-657a89e38b91)

> * Provide the instructions so that we can reproduce.  
Please run this command: https://github.com/HabanaAI/Model-References/tree/1.17.1/PyTorch/nlp/DeepSpeedExamples/deepspeed-bert#pre-training-dataset-preparation
> * Please also list any relevant details for your test configuration.  
I completely followed https://github.com/HabanaAI/Model-References/tree/1.17.1/PyTorch/nlp/DeepSpeedExamples/deepspeed-bert#deepspeed-bert-15b-and-bert-5b-for-pytorch to setup the my test env and config.

## Checklist

- [X] I agree with the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] My code conforms to the following coding guidelines:
  - [X] Use Python 3
  - [X] Python code follows [PEP 8 Coding Styles](https://www.python.org/dev/peps/pep-0008/)
- [X] I have performed a self code review.
- [X] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
